### PR TITLE
Fix bleed effect, improve railgun scaling, and reduce wave delay

### DIFF
--- a/lib/components/bosses/architect_boss.dart
+++ b/lib/components/bosses/architect_boss.dart
@@ -276,8 +276,9 @@ class ArchitectBoss extends BaseEnemy {
       bossPaint,
     );
 
-    // Draw freeze effect and health bar
+    // Draw status effects and health bar
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
     renderHealthBar(canvas);
   }
 

--- a/lib/components/bosses/berserker_boss.dart
+++ b/lib/components/bosses/berserker_boss.dart
@@ -362,8 +362,9 @@ class BerserkerBoss extends BaseEnemy {
       }
     }
 
-    // Draw freeze effect if frozen
+    // Draw status effects
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
 
     // Draw health bar
     renderHealthBar(canvas);

--- a/lib/components/bosses/fortress_boss.dart
+++ b/lib/components/bosses/fortress_boss.dart
@@ -253,8 +253,9 @@ class FortressBoss extends BaseEnemy {
       bossPaint,
     );
 
-    // Draw freeze effect and health bar
+    // Draw status effects and health bar
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
     renderHealthBar(canvas);
   }
 

--- a/lib/components/bosses/gunship_boss.dart
+++ b/lib/components/bosses/gunship_boss.dart
@@ -362,8 +362,9 @@ class GunshipBoss extends BaseEnemy {
       );
     }
 
-    // Draw health bar and freeze effect
+    // Draw status effects and health bar
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
     renderHealthBar(canvas);
   }
 

--- a/lib/components/bosses/hydra_boss.dart
+++ b/lib/components/bosses/hydra_boss.dart
@@ -278,8 +278,9 @@ class HydraBoss extends BaseEnemy {
       bossPaint,
     );
 
-    // Draw freeze effect and health bar
+    // Draw status effects and health bar
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
     renderHealthBar(canvas);
   }
 

--- a/lib/components/bosses/nexus_boss.dart
+++ b/lib/components/bosses/nexus_boss.dart
@@ -514,8 +514,9 @@ class NexusBoss extends BaseEnemy {
       );
     }
 
-    // Draw freeze effect and health bar
+    // Draw status effects and health bar
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
     renderHealthBar(canvas);
   }
 

--- a/lib/components/bosses/shielder_boss.dart
+++ b/lib/components/bosses/shielder_boss.dart
@@ -282,8 +282,9 @@ class ShielderBoss extends BaseEnemy {
       bossPaint,
     );
 
-    // Draw freeze effect if frozen
+    // Draw status effects
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
 
     // Draw health bar
     renderHealthBar(canvas);

--- a/lib/components/bosses/splitter_boss.dart
+++ b/lib/components/bosses/splitter_boss.dart
@@ -302,8 +302,9 @@ class SplitterBoss extends BaseEnemy {
       ..strokeWidth = 2;
     canvas.drawPath(path, strokePaint);
 
-    // Draw health bar and freeze effect
+    // Draw status effects and health bar
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
     renderHealthBar(canvas);
   }
 

--- a/lib/components/bosses/summoner_boss.dart
+++ b/lib/components/bosses/summoner_boss.dart
@@ -404,8 +404,9 @@ class SummonerBoss extends BaseEnemy {
       bossPaint,
     );
 
-    // Draw freeze effect if frozen
+    // Draw status effects
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
 
     // Draw health bar
     renderHealthBar(canvas);

--- a/lib/components/bosses/vortex_boss.dart
+++ b/lib/components/bosses/vortex_boss.dart
@@ -361,8 +361,9 @@ class VortexBoss extends BaseEnemy {
       );
     }
 
-    // Draw freeze effect and health bar
+    // Draw status effects and health bar
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
     renderHealthBar(canvas);
   }
 

--- a/lib/components/enemies/kamikaze_enemy.dart
+++ b/lib/components/enemies/kamikaze_enemy.dart
@@ -140,9 +140,11 @@ class KamikazeEnemy extends BaseEnemy {
       );
     }
 
-    // Draw health bar
-    // Draw freeze effect if frozen
+    // Draw status effects
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
+
+    // Draw health bar
     renderHealthBar(canvas);
   }
 

--- a/lib/components/enemies/pentagon_enemy.dart
+++ b/lib/components/enemies/pentagon_enemy.dart
@@ -88,9 +88,11 @@ class PentagonEnemy extends BaseEnemy {
     canvas.drawPath(path, paint);
     canvas.drawPath(path, strokePaint);
 
-    // Draw health bar
-    // Draw freeze effect if frozen
+    // Draw status effects
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
+
+    // Draw health bar
     renderHealthBar(canvas);
   }
 

--- a/lib/components/enemies/ranger_enemy.dart
+++ b/lib/components/enemies/ranger_enemy.dart
@@ -156,9 +156,11 @@ class RangerEnemy extends BaseEnemy {
       );
     }
 
-    // Draw health bar
-    // Draw freeze effect if frozen
+    // Draw status effects
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
+
+    // Draw health bar
     renderHealthBar(canvas);
   }
 

--- a/lib/components/enemies/scout_enemy.dart
+++ b/lib/components/enemies/scout_enemy.dart
@@ -131,9 +131,11 @@ class ScoutEnemy extends BaseEnemy {
     canvas.drawPath(path, paint);
     canvas.drawPath(path, strokePaint);
 
-    // Draw health bar
-    // Draw freeze effect if frozen
+    // Draw status effects
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
+
+    // Draw health bar
     renderHealthBar(canvas);
 
     // Draw state indicator

--- a/lib/components/enemies/square_enemy.dart
+++ b/lib/components/enemies/square_enemy.dart
@@ -70,8 +70,9 @@ class SquareEnemy extends BaseEnemy {
     canvas.drawRect(rect, paint);
     canvas.drawRect(rect, strokePaint);
 
-    // Draw freeze effect if frozen
+    // Draw status effects
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
 
     // Draw health bar
     renderHealthBar(canvas);

--- a/lib/components/enemies/tank_enemy.dart
+++ b/lib/components/enemies/tank_enemy.dart
@@ -146,9 +146,11 @@ class TankEnemy extends BaseEnemy {
       );
     }
 
-    // Draw health bar
-    // Draw freeze effect if frozen
+    // Draw status effects
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
+
+    // Draw health bar
     renderHealthBar(canvas);
   }
 

--- a/lib/components/enemies/triangle_enemy.dart
+++ b/lib/components/enemies/triangle_enemy.dart
@@ -84,8 +84,9 @@ class TriangleEnemy extends BaseEnemy {
     canvas.drawPath(path, paint);
     canvas.drawPath(path, strokePaint);
 
-    // Draw freeze effect if frozen
+    // Draw status effects
     renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
 
     // Draw health bar
     renderHealthBar(canvas);

--- a/lib/managers/enemy_manager.dart
+++ b/lib/managers/enemy_manager.dart
@@ -22,7 +22,7 @@ class EnemyManager extends Component with HasGameRef<SpaceShooterGame> {
   int enemiesToSpawnInWave = 10;
   bool isWaveActive = false;
   bool isBossWave = false;
-  double waveDelay = 2.0; // Faster wave transitions (was 3.0)
+  double waveDelay = 1.0; // Faster wave transitions (was 2.0)
   double waveTimer = 0;
 
   // Boss pool for waves 55+ (excludes Nexus which only appears at wave 50)

--- a/web/index.html
+++ b/web/index.html
@@ -18,18 +18,18 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="Space Shooter - A fast-paced arcade shooter with waves of enemies, powerful upgrades, and global leaderboards. Survive as long as you can!">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">
-  <meta name="apple-mobile-web-app-title" content="space_shooter">
+  <meta name="apple-mobile-web-app-title" content="Space Shooter">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>space_shooter</title>
+  <title>Space Shooter</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>


### PR DESCRIPTION
## Summary
- **Fixed bleed effect**: Enemies now properly take damage over time when hit with the Bleeding Edge upgrade
- **Improved railgun scaling**: Better damage-to-fire-rate ratio and visual scaling based on power
- **Reduced wave delay**: Faster wave transitions for better pacing

## Changes

### Bleed Effect Implementation
- Added bleed tracking to `BaseEnemy` (isBleeding, bleedTimer, bleedDamagePerSecond)
- Bleed effect applied when player has `bleedDamage > 0` via the Bleeding Edge upgrade
- Enemies take 5 DPS for 3 seconds after being hit
- Visual indicator: red border on bleeding enemies
- Updated all enemy and boss render methods to show bleed effect

### Railgun Improvements
- **Damage**: 2.5x → 4.0x (better compensation for slow fire rate)
- **Fire rate**: 3.0x → 2.5x penalty (fires 20% faster than before)
- **Visual scaling**: Beam width now scales with damage (4-12px)
- **Hit detection**: Beam hit radius scales with damage for better enemy detection

### Wave Delay
- Reduced from 2.0s to 1.0s for faster pacing between waves

### Minor Updates
- Updated `index.html` with proper game description and title

## Test plan
- [x] Verify bleed effect works (enemies take damage over time, red border appears)
- [x] Test chain lightning stacking (confirmed already working)
- [x] Test health regen (confirmed already working)
- [x] Test railgun scaling with high damage builds
- [x] Verify wave transitions are faster
- [x] Code analysis passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)