### PR TITLE
feat: v0.4.0 — issue #36 fixes and combat balance pass

### DIFF
--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -1,5 +1,39 @@
 [
   {
+    "version": "0.4.0",
+    "title": "Bug Fixes & Combat Balance",
+    "date": "2026-06-19",
+    "sections": [
+      {
+        "title": "Bug Fixes",
+        "emoji": "🐛",
+        "items": [
+          "Explosions now combine in the correct spot when shots land together",
+          "Level-ups offer at most one new weapon at a time",
+          "Berserker Rage no longer reappears after you've taken it"
+        ]
+      },
+      {
+        "title": "Balance",
+        "emoji": "⚖️",
+        "items": [
+          "Life steal healing reduced and capped",
+          "Shorter invincibility window after taking a hit",
+          "Laser Beam damage greatly increased",
+          "Rare, Epic and Legendary upgrades appear more often",
+          "Multi-shot can now reach up to 7 projectiles"
+        ]
+      },
+      {
+        "title": "Improvements",
+        "emoji": "✨",
+        "items": [
+          "New shield charge bar under your ship shows when the next shield is ready"
+        ]
+      }
+    ]
+  },
+  {
     "version": "0.3.18",
     "title": "Consistent Multi-Shot Spread",
     "date": "2025-12-07",

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -213,8 +213,9 @@ class Bullet extends BaseRenderedComponent with CollisionCallbacks, HasVisualCen
     final nearbyExplosion = _findNearbyExplosionEffect(position);
 
     if (nearbyExplosion != null) {
-      // Merge: expand existing effect instead of creating a new one
-      nearbyExplosion.mergeWith(player.explosionRadius);
+      // Merge: expand existing effect and pull it toward the new impact so the
+      // combined explosion sits at the correct (averaged) location
+      nearbyExplosion.mergeWith(player.explosionRadius, position);
     } else {
       // No nearby effect, create new visual effect
       final explosion = ExplosionEffect(
@@ -230,6 +231,9 @@ class Bullet extends BaseRenderedComponent with CollisionCallbacks, HasVisualCen
     final allEffects = game.world.children.whereType<ExplosionEffect>();
 
     for (final effect in allEffects) {
+      // Only merge with effects from the same burst: close in space AND created
+      // within the last few milliseconds. Stale effects spawn a fresh explosion.
+      if (effect.age >= BalanceConfig.effectMergeTimeWindow) continue;
       final distance = position.distanceTo(effect.position);
       if (distance <= BalanceConfig.effectMergeRadius) {
         return effect;
@@ -325,6 +329,7 @@ class Bullet extends BaseRenderedComponent with CollisionCallbacks, HasVisualCen
 class ExplosionEffect extends BaseRenderedComponent {
   double radius;
   double lifetime = 0;
+  double age = 0; // Time since spawn (never resets) - gates same-burst merging
   static const double maxLifetime = 0.3; // Short duration
   int mergeCount = 1; // Track how many explosions merged into this one
 
@@ -343,22 +348,28 @@ class ExplosionEffect extends BaseRenderedComponent {
   void update(double dt) {
     super.update(dt);
     lifetime += dt;
+    age += dt;
 
     if (lifetime >= maxLifetime) {
       removeFromParent();
     }
   }
 
-  /// Merge with another explosion - expand radius instead of creating new effect
-  void mergeWith(double newRadius) {
+  /// Merge with another explosion - expand radius and move toward the new impact
+  /// so the combined effect renders at the correct averaged location.
+  void mergeWith(double newRadius, Vector2 newPosition) {
     mergeCount++; // Track merge count for visual feedback
+
+    // Average the position across all merged impacts (incremental mean)
+    position = position + (newPosition - position) / mergeCount.toDouble();
 
     // Expand the radius if the incoming explosion is larger
     if (newRadius > radius) {
       radius = newRadius;
     }
 
-    // Reset lifetime to show effect longer when merging
+    // Reset display lifetime so the merged effect stays visible (merges only
+    // happen within the 20ms window, so this can't make it linger indefinitely)
     lifetime = 0;
   }
 

--- a/lib/components/player_ship.dart
+++ b/lib/components/player_ship.dart
@@ -71,7 +71,7 @@ class PlayerShip extends BaseRenderedComponent
   // Invulnerability frames (prevent multiple collision damage)
   bool isInvulnerable = false;
   double invulnerabilityTimer = 0;
-  static const double invulnerabilityDuration = 1.0; // 1 second of immunity after hit
+  static const double invulnerabilityDuration = 0.3; // 0.3s i-frames after hit (was 1.0s - too long, let players face-tank)
 
   // Damage number rate limiting (for performance at high levels)
   double _lastDamageNumberTime = 0;

--- a/lib/components/player_ship.dart
+++ b/lib/components/player_ship.dart
@@ -546,7 +546,38 @@ class PlayerShip extends BaseRenderedComponent
 
     // Draw shield indicator only if player has shield capacity
     if (maxShieldLayers > 0) {
-      final shieldY = xpBarY + xpBarHeight + 2;
+      var shieldY = xpBarY + xpBarHeight + 2;
+
+      // Draw shield recharge progress bar while a layer is charging, so the
+      // player can see how close the next shield is.
+      if (shieldLayers < maxShieldLayers && shieldRegenInterval > 0) {
+        const shieldBarHeight = 3.0;
+        final shieldBarWidth = healthBarWidth;
+        final shieldBarX = (size.x - shieldBarWidth) / 2;
+
+        final shieldBgPaint = Paint()..color = const Color(0xFF333333);
+        canvas.drawRect(
+          Rect.fromLTWH(shieldBarX, shieldY, shieldBarWidth, shieldBarHeight),
+          shieldBgPaint,
+        );
+
+        final shieldProgress =
+            (shieldRegenTimer / shieldRegenInterval).clamp(0.0, 1.0);
+        final shieldProgressPaint = Paint()..color = const Color(0xFF00BFFF); // Light blue
+        canvas.drawRect(
+          Rect.fromLTWH(
+            shieldBarX,
+            shieldY,
+            shieldBarWidth * shieldProgress,
+            shieldBarHeight,
+          ),
+          shieldProgressPaint,
+        );
+
+        // Move the shield count text below the new progress bar
+        shieldY += shieldBarHeight + 2;
+      }
+
       final shieldText = '🛡️ $shieldLayers/$maxShieldLayers';
       final shieldTextPainter = TextPainter(
         text: TextSpan(

--- a/lib/config/balance_config.dart
+++ b/lib/config/balance_config.dart
@@ -1,7 +1,7 @@
 /// Global balance configuration for easy tuning
 class BalanceConfig {
   // Projectile System
-  static const int maxProjectileCount = 5;
+  static const int maxProjectileCount = 7; // Raised from 5 so multi-shot builds have late-game headroom
 
   // Damage Reduction
   static const double maxDamageReduction = 0.60; // 60% cap

--- a/lib/config/balance_config.dart
+++ b/lib/config/balance_config.dart
@@ -6,6 +6,9 @@ class BalanceConfig {
   // Damage Reduction
   static const double maxDamageReduction = 0.60; // 60% cap
 
+  // Lifesteal (heal-on-hit) - capped to keep sustain in check
+  static const double maxLifesteal = 0.15; // 15% of damage dealt, max
+
   // Damage Numbers (Performance)
   static const double damageNumberCooldown = 0.05; // Show every 50ms (20/sec)
 

--- a/lib/config/balance_config.dart
+++ b/lib/config/balance_config.dart
@@ -24,9 +24,11 @@ class BalanceConfig {
   static const double lootMergeRadius = 60.0; // Drops merge if another loot is within this range
 
   // Effect Pooling (Performance) - Merge overlapping visual effects
-  // When multiple impacts happen in same location (e.g., 10 rockets at once),
-  // merge effects instead of creating duplicates
-  static const double effectMergeRadius = 350.0; // Merge visual effects within this radius
+  // When multiple impacts happen in the same place AND within a tiny time window
+  // (e.g., a multi-shot burst landing together), merge effects into one instead
+  // of stacking duplicates at the wrong spot.
+  static const double effectMergeRadius = 100.0; // Merge only nearby effects (was 350 - too wide, merged distant hits)
+  static const double effectMergeTimeWindow = 0.02; // Only merge effects created < 20ms apart (same burst)
 
   // Wave Scaling
   static const double bleedDamageWaveMultiplier = 0.3; // Bleed damage increases 0.3x per wave after wave 1

--- a/lib/managers/level_manager.dart
+++ b/lib/managers/level_manager.dart
@@ -5,9 +5,10 @@ import '../upgrades/upgrade.dart';
 import '../config/weapon_unlock_config.dart';
 
 class LevelManager extends Component with HasGameReference<SpaceShooterGame> {
-  /// Maximum number of weapon unlocks that can appear in a single upgrade selection
-  /// This ensures players always have stat upgrade options available
-  static const int maxWeaponUpgradesPerSelection = 2;
+  /// Maximum number of weapon unlocks that can appear in a single upgrade selection.
+  /// Capped at 1 so a level-up never offers two weapons at once (issue #36.5) and
+  /// always leaves room for stat upgrades.
+  static const int maxWeaponUpgradesPerSelection = 1;
 
   int currentLevel = 1;
   int currentXP = 0;

--- a/lib/upgrades/upgrade.dart
+++ b/lib/upgrades/upgrade.dart
@@ -1030,15 +1030,17 @@ class UpgradeFactory {
 
     for (int i = 0; i < count; i++) {
       // Weighted rarity selection
-      // 75% common, 20% rare, 4% epic, 1% legendary
+      // 70% common, 20% rare, 6% epic, 4% legendary
+      // (epic/legendary were over-cut to 4%/1% - players rarely saw build-defining
+      // upgrades; restored to keep a sense of progression without flooding them)
       final rarityRoll = random.nextDouble();
       UpgradeRarity targetRarity;
 
-      if (rarityRoll < 0.75) {
+      if (rarityRoll < 0.70) {
         targetRarity = UpgradeRarity.common;
-      } else if (rarityRoll < 0.95) {
+      } else if (rarityRoll < 0.90) {
         targetRarity = UpgradeRarity.rare;
-      } else if (rarityRoll < 0.99) {
+      } else if (rarityRoll < 0.96) {
         targetRarity = UpgradeRarity.epic;
       } else {
         targetRarity = UpgradeRarity.legendary;

--- a/lib/upgrades/upgrade.dart
+++ b/lib/upgrades/upgrade.dart
@@ -294,7 +294,7 @@ class CritDamageUpgrade extends Upgrade {
 class LifestealUpgrade extends Upgrade {
   final double lifestealPercent;
 
-  LifestealUpgrade({this.lifestealPercent = 0.1})
+  LifestealUpgrade({this.lifestealPercent = 0.05})
       : super(
           id: 'lifesteal',
           name: 'Lifesteal',
@@ -304,7 +304,8 @@ class LifestealUpgrade extends Upgrade {
 
   @override
   void apply(PlayerShip player) {
-    player.lifesteal += lifestealPercent;
+    player.lifesteal = (player.lifesteal + lifestealPercent)
+        .clamp(0.0, BalanceConfig.maxLifesteal);
   }
 
   @override
@@ -691,7 +692,8 @@ class VampiricAuraUpgrade extends Upgrade {
 
   @override
   void apply(PlayerShip player) {
-    player.lifesteal += 0.2;
+    player.lifesteal = (player.lifesteal + 0.1)
+        .clamp(0.0, BalanceConfig.maxLifesteal);
     player.magnetRadius += 100; // Also increase magnet radius
   }
 
@@ -703,7 +705,7 @@ class VampiricAuraUpgrade extends Upgrade {
 
   @override
   List<String> getStatusChanges() => [
-    '+20% lifesteal',
+    '+10% lifesteal',
     '+100 magnet radius'
   ];
 }

--- a/lib/upgrades/upgrade.dart
+++ b/lib/upgrades/upgrade.dart
@@ -601,8 +601,9 @@ class BerserkerRageUpgrade extends Upgrade {
   }
 
   @override
-  bool isValidForPlayer(PlayerShip player) {
-    // Don't show if player already has berserk
+  bool isValidFor(PlayerShip player) {
+    // Don't show if player already has berserk (was named isValidForPlayer,
+    // which the selector never calls - so berserk could be offered repeatedly)
     return player.berserkMultiplier == 0;
   }
 

--- a/lib/weapons/laser_beam.dart
+++ b/lib/weapons/laser_beam.dart
@@ -18,8 +18,8 @@ class LaserBeam extends Weapon {
           id: ID,
           name: 'Laser Beam',
           description: 'Continuous damage beam with moderate range',
-          damageMultiplier: 0.4, // Lower damage per tick, but continuous
-          fireRateMultiplier: 0.15, // Very fast fire rate for continuous beam effect
+          damageMultiplier: 0.7, // Buffed from 0.4 - total DPS was far below other weapons
+          fireRateMultiplier: 0.22, // Slightly slower ticks (from 0.15) so the buff lands cleanly
           projectileSpeedMultiplier: 1.0, // Not used for instant beam
         );
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,10 +77,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
@@ -236,26 +236,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   objective_c:
     dependency: transitive
     description:
@@ -465,10 +465,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: space_shooter
 description: "A new Flutter project."
 publish_to: 'none'
-version: 0.3.18
+version: 0.4.0
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
## Summary
Closes the open bug list in #36 and does a focused balance/upgrades pass on top of the pending v0.3.18 multi-shot spawn fix. Ships as one release: **v0.4.0**. Each change is its own merge commit on the branch for granular review.

## Changes

### Bug fixes (issue #36)
- **Explosions merged at the wrong spot.** Bullet hit-explosions merged with any effect within 350px regardless of timing and kept the first explosion's position, so separate hits collapsed into one explosion in the wrong place. Now merging is gated to a 20ms same-burst window, the radius is tightened (350→100), and the merged effect is pulled toward each new impact (averaged location).
- **Two weapons per level-up.** A single level-up could surface two weapon-unlock cards (`maxWeaponUpgradesPerSelection = 2`). Capped to 1.
- **Berserker Rage kept reappearing.** Its validity check was named `isValidForPlayer`, which the upgrade selector never calls (it uses `isValidFor`) — a dead override, so the once-only guard never worked. Renamed.

### Balance
- **Life steal** reduced (base 10%→5%, Vampiric Aura 20%→10%) with a new 15% hard cap.
- **Post-hit invincibility** 1.0s → 0.3s (a full second let players face-tank swarms).
- **Laser Beam** buffed (0.4/0.15 → 0.7/0.22); total DPS was far below every other weapon.
- **Upgrade rarity** restored: epic/legendary were over-cut to 4%/1% last patch → 6%/4% (70/20/6/4).
- **Multi-shot ceiling** 5 → 7 for late-game build headroom.

### Improvements
- **Shield charge bar** under the ship shows how close the next shield layer is.

## Testing
- `flutter analyze --no-fatal-infos`: 0 errors (also cleared one stray override warning from the Berserker fix).
- Full `flutter build web`: compiles cleanly.
- Behavioral changes (explosion location, shield bar, balance values) were code-reviewed against the relevant systems; not yet manually playtested in-game.

## Notes
- **Held back intentionally:** a proposed additive→exponential enemy-health scaling change (large difficulty-feel swing) was left out for a separate, playtested decision.
- After merge, tag `v0.4.0` to trigger the release CI.

Closes #36