### PR TITLE
fix: homing hover + rocket explosion location

### DIFF
--- a/lib/components/bosses/hydra_boss.dart
+++ b/lib/components/bosses/hydra_boss.dart
@@ -395,7 +395,7 @@ class _HydraCore extends BaseEnemy {
   @override
   Future<void> addHitbox() async {
     // Use CircleHitbox with radius relative to component size
-    add(CircleHitbox(radius: size.x * 0.45)); // 0.9 means 90% diameter = 0.45 radius
+    add(CircleHitbox(radius: size.x * 0.5)); // Full body - undersized (0.45) hitbox made homing shots circle the core
   }
 
   @override

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -113,7 +113,16 @@ class Bullet extends BaseRenderedComponent with CollisionCallbacks, HasVisualCen
 
     // Calculate direction to target (no offset on target, offset handled at spawn)
     final toTarget = targetEnemy.position - position;
-    if (toTarget.length < 0.01) return; // Too close, avoid division by zero
+    final distance = toTarget.length;
+    if (distance < 0.01) return; // Too close, avoid division by zero
+
+    // Commit-on-approach: once the bullet is inside the target's body, stop
+    // steering and let it fly straight through. Steering aims at the exact
+    // center, so without this the bullet overshoots the center and flips back
+    // and forth - jittering/hovering over the target (worst on large enemies
+    // where the center sits deep inside the body) instead of just hitting it.
+    final lockDistance = max(targetEnemy.size.x * 0.5, 20.0);
+    if (distance <= lockDistance) return;
 
     final targetDirection = toTarget.normalized();
 

--- a/lib/components/missile.dart
+++ b/lib/components/missile.dart
@@ -93,12 +93,19 @@ class Missile extends BaseRenderedComponent
   void _applyHoming(double dt) {
     if (targetEnemy == null) return;
 
+    // Commit-on-approach: once inside the target body, stop steering and fly
+    // straight through so the missile crosses the hitbox instead of orbiting it
+    // (its turn rate is too weak to spiral into large bosses).
+    final distance = PositionUtil.getDistance(this, targetEnemy!);
+    final lockDistance = max(targetEnemy!.size.x * 0.5, 20.0);
+    if (distance <= lockDistance) return;
+
     // Calculate direction to target
     final toTarget = PositionUtil.getDirectionTo(this, targetEnemy!);
 
-    // Smoothly turn towards target
-    // Scale by dt and factor for consistent turn rate with bullets
-    final turnRate = (homingStrength * dt * 0.01).clamp(0.0, 1.0); // Clamp to prevent overshooting
+    // Smoothly turn towards target. 0.05 (was 0.01 - far too weak, missiles
+    // orbited instead of intercepting) gives a usable turn rate.
+    final turnRate = (homingStrength * dt * 0.05).clamp(0.0, 1.0);
     direction = (direction + (toTarget * turnRate)).normalized();
   }
 

--- a/lib/components/missile.dart
+++ b/lib/components/missile.dart
@@ -151,8 +151,9 @@ class Missile extends BaseRenderedComponent
     final nearbyBombEffect = _findNearbyBombEffect(position);
 
     if (nearbyBombEffect != null) {
-      // Merge: expand existing effect instead of creating a new one
-      nearbyBombEffect.mergeWith(explosionRadius);
+      // Merge: expand existing effect and pull it toward this missile's impact
+      // so the combined wave renders at the correct (averaged) location
+      nearbyBombEffect.mergeWith(explosionRadius, position);
     } else {
       // No nearby effect, create new visual wave effect
       final waveEffect = BombWaveEffect(
@@ -168,8 +169,10 @@ class Missile extends BaseRenderedComponent
     final allEffects = game.world.children.whereType<BombWaveEffect>();
 
     for (final effect in allEffects) {
+      // Must actually be young - otherwise a stale blast from a previous volley
+      // wrongly suppresses this missile's splash damage.
+      if (effect.age >= BalanceConfig.effectMergeTimeWindow) continue;
       final distance = position.distanceTo(effect.position);
-      // If effect is very close and just started (young), it's from a recent missile hit
       if (distance <= explosionRadius * 1.5) {
         return effect;
       }
@@ -182,6 +185,9 @@ class Missile extends BaseRenderedComponent
     final allEffects = game.world.children.whereType<BombWaveEffect>();
 
     for (final effect in allEffects) {
+      // Only merge with same-burst effects: nearby AND just created, so a new
+      // rocket never snaps onto a stale wave at the wrong spot.
+      if (effect.age >= BalanceConfig.effectMergeTimeWindow) continue;
       final distance = position.distanceTo(effect.position);
       if (distance <= BalanceConfig.effectMergeRadius) {
         return effect;

--- a/lib/components/power_ups/bomb_power_up.dart
+++ b/lib/components/power_ups/bomb_power_up.dart
@@ -54,8 +54,8 @@ class BombPowerUp extends BasePowerUp {
     final nearbyBombEffect = _findNearbyBombEffect(playerPosition);
 
     if (nearbyBombEffect != null) {
-      // Merge: expand existing effect instead of creating a new one
-      nearbyBombEffect.mergeWith(bombRange);
+      // Merge: expand existing effect and pull it toward this blast's location
+      nearbyBombEffect.mergeWith(bombRange, playerPosition);
     } else {
       // No nearby effect, create new visual wave effect
       final waveEffect = BombWaveEffect(
@@ -73,6 +73,9 @@ class BombPowerUp extends BasePowerUp {
     final allEffects = game.world.children.whereType<BombWaveEffect>();
 
     for (final effect in allEffects) {
+      // Only merge with same-burst effects: nearby AND just created. Otherwise
+      // a new blast snaps onto a stale wave at the wrong location.
+      if (effect.age >= BalanceConfig.effectMergeTimeWindow) continue;
       final distance = position.distanceTo(effect.position);
       if (distance <= BalanceConfig.effectMergeRadius) {
         return effect;
@@ -148,6 +151,9 @@ class BombWaveEffect extends PositionComponent {
   double _currentRadius = 0.0;
   double _opacity = 1.0;
 
+  /// Time since this effect spawned - used to gate same-burst merging.
+  double get age => _elapsedTime;
+
   BombWaveEffect({
     required Vector2 position,
     this.maxRadius = 400.0,
@@ -175,9 +181,14 @@ class BombWaveEffect extends PositionComponent {
     }
   }
 
-  /// Merge with another bomb explosion - expand radius instead of creating new effect
-  void mergeWith(double newMaxRadius) {
+  /// Merge with another bomb explosion - expand radius and move toward the new
+  /// impact so the combined wave renders at the correct (averaged) location
+  /// instead of staying at the first explosion's spot.
+  void mergeWith(double newMaxRadius, Vector2 newPosition) {
     mergeCount++; // Track merge count for visual feedback
+
+    // Average the position across all merged impacts (incremental mean)
+    position = position + (newPosition - position) / mergeCount.toDouble();
 
     // Expand the max radius if the incoming bomb is larger
     if (newMaxRadius > maxRadius) {
@@ -186,10 +197,8 @@ class BombWaveEffect extends PositionComponent {
       maxRadius = newMaxRadius;
       _currentRadius *= radiusRatio;
     }
-
-    // Reset elapsed time to show the effect longer when merging
-    // This prevents multiple quick merges from instantly completing the effect
-    _elapsedTime = 0;
+    // Note: elapsed time is intentionally NOT reset - `age` gates same-burst
+    // merging, so resetting it would let the effect merge forever.
   }
 
   /// Get color based on merge count for visual feedback

--- a/lib/config/balance_config.dart
+++ b/lib/config/balance_config.dart
@@ -24,9 +24,11 @@ class BalanceConfig {
   static const double lootMergeRadius = 60.0; // Drops merge if another loot is within this range
 
   // Effect Pooling (Performance) - Merge overlapping visual effects
-  // When multiple impacts happen in same location (e.g., 10 rockets at once),
-  // merge effects instead of creating duplicates
-  static const double effectMergeRadius = 350.0; // Merge visual effects within this radius
+  // When multiple impacts happen in the same place AND within a tiny time window
+  // (e.g., a salvo of rockets landing together), merge them into one effect
+  // instead of stacking duplicates at a stale location.
+  static const double effectMergeRadius = 120.0; // Merge only nearby effects (was 350 - merged distant hits)
+  static const double effectMergeTimeWindow = 0.02; // Only merge effects created < 20ms apart (same burst)
 
   // Wave Scaling
   static const double bleedDamageWaveMultiplier = 0.3; // Bleed damage increases 0.3x per wave after wave 1


### PR DESCRIPTION
Two gameplay bug fixes, one per commit. **Please review before merging.**

## 1. Homing projectiles hover/orbit large targets (`c3b692a`)
Homing aimed at the enemy's exact center:
- **Bullets** snap straight at the center every frame (`turnRate` saturates to 1.0), so near a target they overshoot the center and flip back and forth — jittering/"hovering," worst on large bosses where the center sits deep inside the body.
- **Missiles** had a turn rate ~120× weaker (`dt*0.01`), so they orbited large targets instead of intercepting.

**Fix:** commit-on-approach — once a shot is within the target's body radius, stop steering and fly straight through so it crosses the hitbox. Missile turn rate `0.01 → 0.05`. Hydra core hitbox `0.45 → 0.5` (the undersized hitbox let shots circle the core).

## 2. Rocket explosions render in the wrong spot (`d02e906`)
`BombWaveEffect` merging kept the first effect's position and merged with effects up to 0.75s old within 350px — so a rocket's blast appeared where an *earlier* rocket hit. The "is it young?" guard meant to prevent duplicate splash damage was never actually implemented, so a stale nearby blast could cancel a fresh rocket's AoE entirely.

**Fix:** `mergeWith` averages position toward each new impact; all merge/dedup lookups gated on a 20ms same-burst window (`effect.age`); `effectMergeRadius` `350 → 120`.

## Verification
- `flutter analyze`: 0 errors. Full `flutter build web`: compiles cleanly.
- ⚠️ **Not playtested in-game** — the homing `lockDistance`/turn-rate constants are sensible defaults but may want a feel-tune once you try them.

## Notes
- Branched from `main` (0.3.17), code-only. **No version/changelog bump** — that's intentional: PR #37 already claims `0.4.0`, so I left versioning out to avoid a guaranteed `changelog.json` conflict. Tell me the intended merge order (this before/after #37) and I'll add the right bump + changelog entry.