### PR TITLE
feat: holographic restyle + new enemies & boss (vertical slice)

### DIFF
--- a/lib/components/bosses/prism_boss.dart
+++ b/lib/components/bosses/prism_boss.dart
@@ -1,0 +1,204 @@
+import 'dart:math';
+import 'dart:ui';
+import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
+import '../../utils/position_util.dart';
+import '../../factories/enemy_factory.dart';
+import '../../config/enemy_spawn_config.dart';
+import '../../rendering/holographic.dart';
+import '../enemies/base_enemy.dart';
+import '../player_ship.dart';
+import '../enemy_bullet.dart';
+
+/// Aegis Prism - a holographic boss for the wave 55+ rotation.
+///
+/// - Orbits the player at range, rotating wireframe prism body
+/// - Fires rotating rings of holo-bolts
+/// - Periodically summons Weaver adds (capped)
+/// - Enrages below 50% HP: faster, denser bolt rings
+class PrismBoss extends BaseEnemy {
+  static const String ID = 'prism_boss'; // must contain 'boss' for boss selection
+
+  static const double orbitDistance = 330;
+  static const double orbitSpeed = 55;
+
+  static const double burstInterval = 2.2;
+  static const double summonInterval = 7.0;
+  static const int maxAdds = 4;
+  static const double bulletSpeed = 165;
+  static const double bulletDamage = 18;
+
+  double _spin = 0;
+  double _pulse = 0;
+  double _ringOffset = 0;
+  double _burstTimer = 0;
+  double _summonTimer = 0;
+  double _hitFlash = 0;
+  final List<BaseEnemy> _adds = [];
+
+  PrismBoss({
+    required Vector2 position,
+    required PlayerShip player,
+    required int wave,
+    double scale = 1.0,
+  }) : super(
+          position: position,
+          player: player,
+          wave: wave,
+          health: 600 + (wave * 80),
+          speed: 30 + (wave * 0.6),
+          lootValue: 55,
+          color: Holo.purple,
+          size: Vector2(68, 68) * scale,
+          contactDamage: 32.0,
+        );
+
+  bool get isEnraged => health < maxHealth * 0.5;
+
+  @override
+  Future<void> addHitbox() async {
+    // Hexagon hitbox covering the prism body
+    final verts = <Vector2>[];
+    final cx = size.x / 2, cy = size.y / 2;
+    for (int i = 0; i < 6; i++) {
+      final a = (i * 2 * pi / 6) - pi / 2;
+      verts.add(Vector2(cx + cos(a) * size.x / 2, cy + sin(a) * size.y / 2));
+    }
+    add(PolygonHitbox(verts));
+  }
+
+  @override
+  void updateMovement(double dt) {
+    if (_hitFlash > 0) _hitFlash = max(0, _hitFlash - dt * 4);
+    _spin += dt * (isEnraged ? 1.6 : 0.9);
+    _pulse += dt * 4;
+
+    // Orbit the player
+    final distance = PositionUtil.getDistance(this, player);
+    final toPlayer = PositionUtil.getDirectionTo(this, player);
+    if (distance < orbitDistance - 50) {
+      position += toPlayer * -getEffectiveSpeed() * dt;
+    } else if (distance > orbitDistance + 50) {
+      position += toPlayer * getEffectiveSpeed() * dt;
+    } else {
+      final perpendicular = Vector2(-toPlayer.y, toPlayer.x);
+      position += perpendicular * orbitSpeed * dt;
+    }
+
+    // Bolt rings
+    _burstTimer += dt;
+    final interval = isEnraged ? burstInterval * 0.6 : burstInterval;
+    if (_burstTimer >= interval) {
+      _fireRing(isEnraged ? 14 : 10);
+      _burstTimer = 0;
+    }
+
+    // Summon adds
+    _adds.removeWhere((a) => a.isRemoved);
+    _summonTimer += dt;
+    if (_summonTimer >= summonInterval && _adds.length < maxAdds) {
+      _summonAdds();
+      _summonTimer = 0;
+    }
+  }
+
+  void _fireRing(int count) {
+    for (int i = 0; i < count; i++) {
+      final a = _ringOffset + i * 2 * pi / count;
+      final dir = Vector2(cos(a), sin(a));
+      final bullet = EnemyBullet(
+        position: position.clone(),
+        direction: dir,
+        damage: bulletDamage,
+        speed: bulletSpeed,
+      );
+      bullet.size = Vector2.all(11);
+      game.world.add(bullet);
+    }
+    _ringOffset += 0.4; // rotate each successive ring for a spiral feel
+  }
+
+  void _summonAdds() {
+    final random = Random();
+    final count = min(2, maxAdds - _adds.length);
+    for (int i = 0; i < count; i++) {
+      final offset = Vector2(
+        (random.nextDouble() - 0.5) * size.x * 3,
+        (random.nextDouble() - 0.5) * size.x * 3,
+      );
+      final add = EnemyFactory.create(
+        'weaver', // Weaver adds (string id avoids an import cycle)
+        player,
+        wave,
+        position.clone() + offset,
+        scale: game.entityScale,
+      );
+      _adds.add(add);
+      game.world.add(add);
+    }
+  }
+
+  @override
+  void takeDamage(double damage, {bool isCrit = false, bool showDamageNumber = true}) {
+    _hitFlash = 1.0;
+    super.takeDamage(damage, isCrit: isCrit, showDamageNumber: showDamageNumber);
+  }
+
+  Path _ring(int sides, double radius, double rot) {
+    final p = Path();
+    final cx = size.x / 2, cy = size.y / 2;
+    for (int i = 0; i < sides; i++) {
+      final a = i * 2 * pi / sides + rot;
+      final x = cx + cos(a) * radius;
+      final y = cy + sin(a) * radius;
+      if (i == 0) {
+        p.moveTo(x, y);
+      } else {
+        p.lineTo(x, y);
+      }
+    }
+    p.close();
+    return p;
+  }
+
+  @override
+  void renderShape(Canvas canvas) {
+    final center = Offset(size.x / 2, size.y / 2);
+    final bodyColor = isEnraged ? Holo.danger : Holo.purple;
+
+    // Rotating targeting brackets
+    Holo.reticle(canvas, center, size.x / 2 + 12, rotation: _spin * 0.6);
+
+    // Outer prism (hexagon) + counter-rotating inner triangle
+    Holo.drawShape(canvas, _ring(6, size.x * 0.5, -pi / 2 + _spin),
+        color: bodyColor, strokeWidth: 2.0, glow: 8, hit: _hitFlash);
+    Holo.drawShape(canvas, _ring(3, size.x * 0.30, -pi / 2 - _spin * 1.3),
+        color: Holo.teal, strokeWidth: 1.6, glow: 6, scanlines: false, hit: _hitFlash);
+
+    // Pulsing core
+    Holo.drawCircle(canvas, center, size.x * 0.10 * (0.85 + 0.15 * sin(_pulse)),
+        color: Holo.white, glow: 7, fillOpacity: 0.4);
+
+    renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
+    renderHealthBar(canvas);
+  }
+
+  static void registerFactory() {
+    EnemyFactory.register(ID, (player, wave, spawnPos, scale) {
+      return PrismBoss(
+        position: spawnPos,
+        player: player,
+        wave: wave,
+        scale: scale,
+      );
+    });
+  }
+
+  static double getSpawnWeight(int wave) => 0.0; // joins via the 55+ bossPool
+
+  static void init() {
+    registerFactory();
+    EnemySpawnConfig.registerSpawnWeight(ID, getSpawnWeight);
+  }
+}

--- a/lib/components/enemies/kamikaze_enemy.dart
+++ b/lib/components/enemies/kamikaze_enemy.dart
@@ -7,6 +7,7 @@ import '../../factories/enemy_factory.dart';
 import '../../config/enemy_spawn_config.dart';
 import 'base_enemy.dart';
 import '../player_ship.dart';
+import '../../rendering/holographic.dart';
 
 /// Kamikaze Enemy: Suicide bomber with explosion
 /// - Pulsing circle, red with warning pulses, size 18x18
@@ -108,20 +109,10 @@ class KamikazeEnemy extends BaseEnemy {
     );
 
     // Draw main circle
-    final paint = Paint()
-      ..color = color
-      ..style = PaintingStyle.fill;
-
-    final strokePaint = Paint()
-      ..color = const Color(0xFFFFFFFF)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2;
-
     final center = Offset(size.x / 2, size.y / 2);
     final radius = (size.x / 2) * pulseScale;
 
-    canvas.drawCircle(center, radius, paint);
-    canvas.drawCircle(center, radius, strokePaint);
+    Holo.drawCircle(canvas, center, radius, color: Holo.danger);
 
     // Draw danger symbol (exclamation mark pattern)
     final distanceToPlayer = PositionUtil.getDistance(this, player);

--- a/lib/components/enemies/lancer_enemy.dart
+++ b/lib/components/enemies/lancer_enemy.dart
@@ -1,0 +1,176 @@
+import 'dart:math';
+import 'dart:ui';
+import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
+import '../../utils/position_util.dart';
+import '../../factories/enemy_factory.dart';
+import '../../config/enemy_spawn_config.dart';
+import '../../rendering/holographic.dart';
+import 'base_enemy.dart';
+import '../player_ship.dart';
+
+/// Lancer: stalks the player, then telegraphs and dashes in a locked straight
+/// line - a dodge-or-get-hit threat. Introduced wave 10+.
+///
+/// Internal phases (kept as plain string state, not an enum type, since it's a
+/// private per-instance FSM rather than an extensible type hierarchy):
+///   approach -> charge (telegraph) -> dash -> recover -> approach
+class LancerEnemy extends BaseEnemy {
+  static const String ID = 'lancer';
+
+  static const double engageDistance = 320; // start charging within this range
+  static const double chargeDuration = 0.7; // telegraph time
+  static const double dashDuration = 0.45;
+  static const double recoverDuration = 1.1;
+  static const double dashSpeed = 540;
+
+  static const String _approach = 'approach';
+  static const String _charge = 'charge';
+  static const String _dash = 'dash';
+  static const String _recover = 'recover';
+
+  String _phase = _approach;
+  double _phaseTimer = 0;
+  Vector2 _dashDir = Vector2(0, 1);
+  double _hitFlash = 0;
+
+  LancerEnemy({
+    required Vector2 position,
+    required PlayerShip player,
+    required int wave,
+    double scale = 1.0,
+  }) : super(
+          position: position,
+          player: player,
+          wave: wave,
+          health: 55 + (wave * 3.5),
+          speed: 55 + (wave * 1.4),
+          lootValue: 3,
+          color: Holo.purple,
+          size: Vector2(26, 26) * scale,
+          contactDamage: 20.0,
+        );
+
+  @override
+  Future<void> addHitbox() async {
+    // Diamond (4 sides, vertex-up)
+    final verts = <Vector2>[];
+    final cx = size.x / 2, cy = size.y / 2;
+    for (int i = 0; i < 4; i++) {
+      final a = (i * 2 * pi / 4) - pi / 2;
+      verts.add(Vector2(cx + cos(a) * size.x / 2, cy + sin(a) * size.y / 2));
+    }
+    add(PolygonHitbox(verts));
+  }
+
+  @override
+  void updateMovement(double dt) {
+    if (_hitFlash > 0) _hitFlash = max(0, _hitFlash - dt * 4);
+    _phaseTimer += dt;
+
+    final toPlayer = PositionUtil.getDirectionTo(this, player);
+    final distance = PositionUtil.getDistance(this, player);
+
+    switch (_phase) {
+      case _approach:
+        position += toPlayer * getEffectiveSpeed() * dt;
+        angle = atan2(toPlayer.y, toPlayer.x) + pi / 2;
+        if (distance <= engageDistance) {
+          _phase = _charge;
+          _phaseTimer = 0;
+        }
+        break;
+
+      case _charge:
+        // Brace and aim: lock onto the player's CURRENT position each frame
+        // until the dash fires, then commit.
+        _dashDir = toPlayer.clone();
+        angle = atan2(toPlayer.y, toPlayer.x) + pi / 2;
+        // slight backward drift to "wind up"
+        position += toPlayer * -getEffectiveSpeed() * 0.3 * dt;
+        if (_phaseTimer >= chargeDuration) {
+          _phase = _dash;
+          _phaseTimer = 0;
+        }
+        break;
+
+      case _dash:
+        position += _dashDir * dashSpeed * dt;
+        if (_phaseTimer >= dashDuration) {
+          _phase = _recover;
+          _phaseTimer = 0;
+        }
+        break;
+
+      case _recover:
+        // brief vulnerable pause
+        if (_phaseTimer >= recoverDuration) {
+          _phase = _approach;
+          _phaseTimer = 0;
+        }
+        break;
+    }
+  }
+
+  @override
+  void takeDamage(double damage, {bool isCrit = false, bool showDamageNumber = true}) {
+    _hitFlash = 1.0;
+    super.takeDamage(damage, isCrit: isCrit, showDamageNumber: showDamageNumber);
+  }
+
+  @override
+  void renderShape(Canvas canvas) {
+    final charging = _phase == _charge;
+    final dashing = _phase == _dash;
+
+    // Telegraph: a danger-coloured aim line while charging.
+    if (charging) {
+      final progress = (_phaseTimer / chargeDuration).clamp(0.0, 1.0);
+      final center = Offset(size.x / 2, size.y / 2);
+      final aim = Offset(_dashDir.x, _dashDir.y);
+      final telePaint = Paint()
+        ..color = Holo.danger.withValues(alpha: 0.35 + 0.4 * progress)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = 2.0
+        ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 3.0);
+      canvas.drawLine(
+        center,
+        center + aim * (size.x * 1.6 + size.x * 2.0 * progress),
+        telePaint,
+      );
+    }
+
+    Holo.drawShape(
+      canvas,
+      Holo.polygonPath(size, 4),
+      color: (charging || dashing) ? Holo.danger : Holo.purple,
+      glow: dashing ? 10 : 6,
+      hit: _hitFlash,
+    );
+
+    renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
+    renderHealthBar(canvas);
+  }
+
+  static void registerFactory() {
+    EnemyFactory.register(ID, (player, wave, spawnPos, scale) {
+      return LancerEnemy(
+        position: spawnPos,
+        player: player,
+        wave: wave,
+        scale: scale,
+      );
+    });
+  }
+
+  static double getSpawnWeight(int wave) {
+    if (wave < 10) return 0.0;
+    return 1.0 + (wave * 0.07);
+  }
+
+  static void init() {
+    registerFactory();
+    EnemySpawnConfig.registerSpawnWeight(ID, getSpawnWeight);
+  }
+}

--- a/lib/components/enemies/pentagon_enemy.dart
+++ b/lib/components/enemies/pentagon_enemy.dart
@@ -7,6 +7,7 @@ import '../../factories/enemy_factory.dart';
 import '../../config/enemy_spawn_config.dart';
 import 'base_enemy.dart';
 import '../player_ship.dart';
+import '../../rendering/holographic.dart';
 
 /// Pentagon Enemy: Slow, high health basic enemy
 /// - Pentagon shape, magenta color
@@ -60,15 +61,6 @@ class PentagonEnemy extends BaseEnemy {
 
   @override
   void renderShape(Canvas canvas) {
-    final paint = Paint()
-      ..color = color
-      ..style = PaintingStyle.fill;
-
-    final strokePaint = Paint()
-      ..color = const Color(0xFFFFFFFF)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2;
-
     // Draw pentagon centered in the bounding box
     final sides = 5;
     final path = Path();
@@ -85,8 +77,7 @@ class PentagonEnemy extends BaseEnemy {
       }
     }
     path.close();
-    canvas.drawPath(path, paint);
-    canvas.drawPath(path, strokePaint);
+    Holo.drawShape(canvas, path, color: Holo.purple);
 
     // Draw status effects
     renderFreezeEffect(canvas);

--- a/lib/components/enemies/ranger_enemy.dart
+++ b/lib/components/enemies/ranger_enemy.dart
@@ -8,6 +8,7 @@ import '../../config/enemy_spawn_config.dart';
 import 'base_enemy.dart';
 import '../player_ship.dart';
 import '../enemy_bullet.dart';
+import '../../rendering/holographic.dart';
 
 /// Ranger Enemy: Ranged shooter, keeps distance
 /// - Star shape (5 points), orange, size 22x22
@@ -111,15 +112,6 @@ class RangerEnemy extends BaseEnemy {
 
   @override
   void renderShape(Canvas canvas) {
-    final paint = Paint()
-      ..color = color
-      ..style = PaintingStyle.fill;
-
-    final strokePaint = Paint()
-      ..color = const Color(0xFFFFFFFF)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2;
-
     // Draw 5-pointed star from top-left coordinate system
     final sides = 5;
     final path = Path();
@@ -139,8 +131,7 @@ class RangerEnemy extends BaseEnemy {
     }
     path.close();
 
-    canvas.drawPath(path, paint);
-    canvas.drawPath(path, strokePaint);
+    Holo.drawShape(canvas, path, color: Holo.purple);
 
     // Draw shoot indicator (charging effect)
     if (shootTimer > shootInterval * 0.8) {

--- a/lib/components/enemies/scout_enemy.dart
+++ b/lib/components/enemies/scout_enemy.dart
@@ -7,6 +7,7 @@ import '../../factories/enemy_factory.dart';
 import '../../config/enemy_spawn_config.dart';
 import 'base_enemy.dart';
 import '../player_ship.dart';
+import '../../rendering/holographic.dart';
 
 /// Scout Enemy: Fast, fragile, zigzag movement
 /// - Diamond shape, cyan color, size 15x15
@@ -108,15 +109,6 @@ class ScoutEnemy extends BaseEnemy {
 
   @override
   void renderShape(Canvas canvas) {
-    final paint = Paint()
-      ..color = color
-      ..style = PaintingStyle.fill;
-
-    final strokePaint = Paint()
-      ..color = const Color(0xFFFFFFFF)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 1.5;
-
     // Draw diamond shape from top-left coordinate system
     final w = size.x;
     final h = size.y;
@@ -128,8 +120,7 @@ class ScoutEnemy extends BaseEnemy {
       ..lineTo(0, h / 2) // Left
       ..close();
 
-    canvas.drawPath(path, paint);
-    canvas.drawPath(path, strokePaint);
+    Holo.drawShape(canvas, path, color: Holo.teal, strokeWidth: 1.4);
 
     // Draw status effects
     renderFreezeEffect(canvas);

--- a/lib/components/enemies/splinter_enemy.dart
+++ b/lib/components/enemies/splinter_enemy.dart
@@ -1,0 +1,122 @@
+import 'dart:math';
+import 'dart:ui';
+import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
+import '../../utils/position_util.dart';
+import '../../factories/enemy_factory.dart';
+import '../../config/enemy_spawn_config.dart';
+import '../../rendering/holographic.dart';
+import 'base_enemy.dart';
+import '../player_ship.dart';
+
+/// Splinter: a chaser that fractures into two smaller copies when destroyed,
+/// until it runs out of splits. Creates swarm pressure. Introduced wave 8+.
+class SplinterEnemy extends BaseEnemy {
+  static const String ID = 'splinter';
+
+  /// Splits left before this becomes terminal. A freshly-spawned Splinter
+  /// starts at [initialSplits]; children get one fewer. 2 -> spawns 2 -> each
+  /// spawns 2 (1 -> 2 -> 4, terminal at 0).
+  static const int initialSplits = 2;
+
+  final int splitsRemaining;
+  final double spawnScale;
+  double _hitFlash = 0;
+
+  SplinterEnemy({
+    required Vector2 position,
+    required PlayerShip player,
+    required int wave,
+    double scale = 1.0,
+    this.splitsRemaining = initialSplits,
+  })  : spawnScale = scale,
+        super(
+          position: position,
+          player: player,
+          wave: wave,
+          // Bigger (more splits left) = tankier
+          health: (16 + (wave * 1.4)) * (0.6 + 0.25 * splitsRemaining),
+          speed: 60 + (wave * 1.6),
+          lootValue: splitsRemaining > 0 ? 1 : 2,
+          color: Holo.teal,
+          size: Vector2.all(14.0 + 7.0 * splitsRemaining) * scale,
+          contactDamage: 10.0,
+        );
+
+  @override
+  Future<void> addHitbox() async {
+    // Hexagon
+    final verts = <Vector2>[];
+    final cx = size.x / 2, cy = size.y / 2;
+    for (int i = 0; i < 6; i++) {
+      final a = (i * 2 * pi / 6) - pi / 2;
+      verts.add(Vector2(cx + cos(a) * size.x / 2, cy + sin(a) * size.y / 2));
+    }
+    add(PolygonHitbox(verts));
+  }
+
+  @override
+  void updateMovement(double dt) {
+    if (_hitFlash > 0) _hitFlash = max(0, _hitFlash - dt * 4);
+    final toPlayer = PositionUtil.getDirectionTo(this, player);
+    position += toPlayer * getEffectiveSpeed() * dt;
+    angle = atan2(toPlayer.y, toPlayer.x) + pi / 2;
+  }
+
+  @override
+  void takeDamage(double damage, {bool isCrit = false, bool showDamageNumber = true}) {
+    _hitFlash = 1.0;
+    super.takeDamage(damage, isCrit: isCrit, showDamageNumber: showDamageNumber);
+  }
+
+  @override
+  void onDeath() {
+    if (splitsRemaining <= 0) return;
+
+    // Spawn two smaller copies offset to either side of the death position.
+    final random = Random();
+    for (int i = 0; i < 2; i++) {
+      final offsetAngle = random.nextDouble() * 2 * pi;
+      final offset = Vector2(cos(offsetAngle), sin(offsetAngle)) * (size.x * 0.6);
+      final child = SplinterEnemy(
+        position: position.clone() + offset,
+        player: player,
+        wave: wave,
+        scale: spawnScale,
+        splitsRemaining: splitsRemaining - 1,
+      );
+      game.world.add(child);
+    }
+  }
+
+  @override
+  void renderShape(Canvas canvas) {
+    Holo.drawShape(canvas, Holo.polygonPath(size, 6),
+        color: Holo.teal, hit: _hitFlash);
+
+    renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
+    renderHealthBar(canvas);
+  }
+
+  static void registerFactory() {
+    EnemyFactory.register(ID, (player, wave, spawnPos, scale) {
+      return SplinterEnemy(
+        position: spawnPos,
+        player: player,
+        wave: wave,
+        scale: scale,
+      );
+    });
+  }
+
+  static double getSpawnWeight(int wave) {
+    if (wave < 8) return 0.0;
+    return 0.9 + (wave * 0.06);
+  }
+
+  static void init() {
+    registerFactory();
+    EnemySpawnConfig.registerSpawnWeight(ID, getSpawnWeight);
+  }
+}

--- a/lib/components/enemies/square_enemy.dart
+++ b/lib/components/enemies/square_enemy.dart
@@ -7,6 +7,7 @@ import '../../factories/enemy_factory.dart';
 import '../../config/enemy_spawn_config.dart';
 import 'base_enemy.dart';
 import '../player_ship.dart';
+import '../../rendering/holographic.dart';
 
 /// Square Enemy: Medium speed, medium health basic enemy
 /// - Square shape, orange color
@@ -56,19 +57,9 @@ class SquareEnemy extends BaseEnemy {
 
   @override
   void renderShape(Canvas canvas) {
-    final paint = Paint()
-      ..color = color
-      ..style = PaintingStyle.fill;
-
-    final strokePaint = Paint()
-      ..color = const Color(0xFFFFFFFF)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2;
-
     // Draw square from top-left (0,0) to (size.x, size.y)
-    final rect = Rect.fromLTWH(0, 0, size.x, size.y);
-    canvas.drawRect(rect, paint);
-    canvas.drawRect(rect, strokePaint);
+    final path = Path()..addRect(Rect.fromLTWH(0, 0, size.x, size.y));
+    Holo.drawShape(canvas, path, color: Holo.blue);
 
     // Draw status effects
     renderFreezeEffect(canvas);

--- a/lib/components/enemies/tank_enemy.dart
+++ b/lib/components/enemies/tank_enemy.dart
@@ -7,6 +7,7 @@ import '../../factories/enemy_factory.dart';
 import '../../config/enemy_spawn_config.dart';
 import 'base_enemy.dart';
 import '../player_ship.dart';
+import '../../rendering/holographic.dart';
 
 /// Tank Enemy: Slow, high health, damage reduction
 /// - Octagon shape, dark red, size 40x40
@@ -90,15 +91,6 @@ class TankEnemy extends BaseEnemy {
 
   @override
   void renderShape(Canvas canvas) {
-    final paint = Paint()
-      ..color = color
-      ..style = PaintingStyle.fill;
-
-    final strokePaint = Paint()
-      ..color = const Color(0xFFFFFFFF)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2.5;
-
     // Draw octagon from top-left coordinate system
     final sides = 8;
     final path = Path();
@@ -118,8 +110,7 @@ class TankEnemy extends BaseEnemy {
     }
     path.close();
 
-    canvas.drawPath(path, paint);
-    canvas.drawPath(path, strokePaint);
+    Holo.drawShape(canvas, path, color: Holo.blue, strokeWidth: 2.0);
 
     // Draw armor indicator (small shield symbol)
     if (timeSinceLastDamage < regenDelay) {

--- a/lib/components/enemies/triangle_enemy.dart
+++ b/lib/components/enemies/triangle_enemy.dart
@@ -7,6 +7,7 @@ import '../../factories/enemy_factory.dart';
 import '../../config/enemy_spawn_config.dart';
 import 'base_enemy.dart';
 import '../player_ship.dart';
+import '../../rendering/holographic.dart';
 
 /// Triangle Enemy: Fast basic enemy
 /// - Triangle shape, red color
@@ -60,15 +61,6 @@ class TriangleEnemy extends BaseEnemy {
 
   @override
   void renderShape(Canvas canvas) {
-    final paint = Paint()
-      ..color = color
-      ..style = PaintingStyle.fill;
-
-    final strokePaint = Paint()
-      ..color = const Color(0xFFFFFFFF)
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2;
-
     // Draw triangle from top-left coordinate system
     final h = size.y;
     final w = size.x;
@@ -81,8 +73,7 @@ class TriangleEnemy extends BaseEnemy {
       ..lineTo(0, bottomY) // Bottom left
       ..close();
 
-    canvas.drawPath(path, paint);
-    canvas.drawPath(path, strokePaint);
+    Holo.drawShape(canvas, path, color: Holo.teal);
 
     // Draw status effects
     renderFreezeEffect(canvas);

--- a/lib/components/enemies/weaver_enemy.dart
+++ b/lib/components/enemies/weaver_enemy.dart
@@ -1,0 +1,107 @@
+import 'dart:math';
+import 'dart:ui';
+import 'package:flame/collisions.dart';
+import 'package:flame/components.dart';
+import '../../utils/position_util.dart';
+import '../../factories/enemy_factory.dart';
+import '../../config/enemy_spawn_config.dart';
+import '../../rendering/holographic.dart';
+import 'base_enemy.dart';
+import '../player_ship.dart';
+
+/// Weaver ("Phantom"): fast, low-HP chaser that weaves side-to-side as it
+/// approaches, making it hard to hit with straight fire. Introduced wave 6+.
+class WeaverEnemy extends BaseEnemy {
+  static const String ID = 'weaver';
+
+  // Weave motion
+  static const double weaveFrequency = 7.0; // oscillations (radians/sec)
+  static const double weaveAmplitude = 140.0; // lateral speed (px/sec)
+
+  double _weavePhase = 0;
+  double _hitFlash = 0;
+
+  WeaverEnemy({
+    required Vector2 position,
+    required PlayerShip player,
+    required int wave,
+    double scale = 1.0,
+  }) : super(
+          position: position,
+          player: player,
+          wave: wave,
+          health: 24 + (wave * 2.0),
+          speed: 95 + (wave * 2.2), // fast
+          lootValue: 2,
+          color: Holo.blue,
+          size: Vector2(22, 22) * scale,
+          contactDamage: 12.0,
+        ) {
+    // Randomise starting phase so a group doesn't weave in lockstep.
+    _weavePhase = Random().nextDouble() * 2 * pi;
+  }
+
+  @override
+  Future<void> addHitbox() async {
+    final verts = <Vector2>[];
+    final cx = size.x / 2, cy = size.y / 2;
+    for (int i = 0; i < 3; i++) {
+      final a = (i * 2 * pi / 3) - pi / 2;
+      verts.add(Vector2(cx + cos(a) * size.x / 2, cy + sin(a) * size.y / 2));
+    }
+    add(PolygonHitbox(verts));
+  }
+
+  @override
+  void updateMovement(double dt) {
+    if (_hitFlash > 0) _hitFlash = max(0, _hitFlash - dt * 4);
+
+    _weavePhase += weaveFrequency * dt;
+
+    final toPlayer = PositionUtil.getDirectionTo(this, player);
+    final perpendicular = Vector2(-toPlayer.y, toPlayer.x);
+    final lateral = sin(_weavePhase) * weaveAmplitude;
+
+    position += (toPlayer * getEffectiveSpeed() + perpendicular * lateral) * dt;
+
+    // Face the blended travel direction
+    angle = atan2(toPlayer.y, toPlayer.x) + pi / 2;
+  }
+
+  @override
+  void takeDamage(double damage, {bool isCrit = false, bool showDamageNumber = true}) {
+    _hitFlash = 1.0;
+    super.takeDamage(damage, isCrit: isCrit, showDamageNumber: showDamageNumber);
+  }
+
+  @override
+  void renderShape(Canvas canvas) {
+    Holo.drawShape(canvas, Holo.polygonPath(size, 3),
+        color: Holo.blue, hit: _hitFlash);
+
+    renderFreezeEffect(canvas);
+    renderBleedEffect(canvas);
+    renderHealthBar(canvas);
+  }
+
+  static void registerFactory() {
+    EnemyFactory.register(ID, (player, wave, spawnPos, scale) {
+      return WeaverEnemy(
+        position: spawnPos,
+        player: player,
+        wave: wave,
+        scale: scale,
+      );
+    });
+  }
+
+  static double getSpawnWeight(int wave) {
+    if (wave < 6) return 0.0;
+    return 1.2 + (wave * 0.08);
+  }
+
+  static void init() {
+    registerFactory();
+    EnemySpawnConfig.registerSpawnWeight(ID, getSpawnWeight);
+  }
+}

--- a/lib/game/space_shooter_game.dart
+++ b/lib/game/space_shooter_game.dart
@@ -34,9 +34,13 @@ import '../components/enemies/scout_enemy.dart';
 import '../components/enemies/tank_enemy.dart';
 import '../components/enemies/ranger_enemy.dart';
 import '../components/enemies/kamikaze_enemy.dart';
+import '../components/enemies/weaver_enemy.dart';
+import '../components/enemies/lancer_enemy.dart';
+import '../components/enemies/splinter_enemy.dart';
 
 // Import all bosses for factory registration
 import '../components/bosses/shielder_boss.dart';
+import '../components/bosses/prism_boss.dart';
 import '../components/bosses/berserker_boss.dart';
 import '../components/bosses/gunship_boss.dart';
 import '../components/bosses/splitter_boss.dart';
@@ -118,9 +122,13 @@ class SpaceShooterGame extends FlameGame
     TankEnemy.init();
     RangerEnemy.init();
     KamikazeEnemy.init();
+    WeaverEnemy.init();
+    LancerEnemy.init();
+    SplinterEnemy.init();
 
     // Register all bosses
     ShielderBoss.init();
+    PrismBoss.init();
     BerserkerBoss.init();
     GunshipBoss.init();
     SplitterBoss.init();

--- a/lib/managers/enemy_manager.dart
+++ b/lib/managers/enemy_manager.dart
@@ -43,6 +43,7 @@ class EnemyManager extends Component with HasGameReference<SpaceShooterGame> {
     'berserker',         // Wave 35
     'architect_boss',    // Wave 40
     'hydra_boss',        // Wave 45
+    'prism_boss',        // Aegis Prism (holographic) - pool-only
   ];
 
   EnemyManager({required this.player, required SpaceShooterGame game});

--- a/lib/rendering/holographic.dart
+++ b/lib/rendering/holographic.dart
@@ -1,0 +1,147 @@
+import 'dart:math';
+import 'dart:ui';
+
+import 'package:flame/components.dart';
+
+/// Shared sci-fi HOLOGRAPHIC rendering system.
+///
+/// Every enemy/boss routes its shape through this so the whole roster reads as
+/// one cohesive look: a translucent holo-fill, faint scanlines, a soft glow halo
+/// and a bright wireframe outline. Keeping the drawing here (instead of each
+/// component hand-rolling Paints) is the single source of truth for the style -
+/// retuning the palette or glow updates every enemy at once.
+class Holo {
+  Holo._();
+
+  // Palette (teal / blue / purple on deep navy)
+  static const Color teal = Color(0xFF38F9D7);
+  static const Color blue = Color(0xFF43A0FF);
+  static const Color purple = Color(0xFFB16CFF);
+  static const Color bg = Color(0xFF05101A);
+  static const Color white = Color(0xFFEAFBFF);
+  static const Color danger = Color(0xFFFF5C7A); // telegraph / enraged accents
+
+  /// Build a regular-polygon [Path] centred in a [size] box (top-left origin).
+  /// [rotation] of -pi/2 puts the first vertex at the top (matches the existing
+  /// enemy shapes).
+  static Path polygonPath(Vector2 size, int sides, {double rotation = -pi / 2}) {
+    final path = Path();
+    final cx = size.x / 2;
+    final cy = size.y / 2;
+    final rx = size.x / 2;
+    final ry = size.y / 2;
+    for (int i = 0; i < sides; i++) {
+      final a = (i * 2 * pi / sides) + rotation;
+      final x = cx + cos(a) * rx;
+      final y = cy + sin(a) * ry;
+      if (i == 0) {
+        path.moveTo(x, y);
+      } else {
+        path.lineTo(x, y);
+      }
+    }
+    path.close();
+    return path;
+  }
+
+  /// Draw a holographic shape: glow halo + translucent fill + faint scanlines +
+  /// bright wireframe outline.
+  ///
+  /// [hit] (0..1) flashes the shape toward white for damage feedback - pass a
+  /// decaying value from the component.
+  static void drawShape(
+    Canvas canvas,
+    Path path, {
+    Color color = teal,
+    double strokeWidth = 1.6,
+    double glow = 6.0,
+    double fillOpacity = 0.16,
+    bool scanlines = true,
+    double hit = 0.0,
+    Rect? bounds,
+  }) {
+    final lineColor = Color.lerp(color, white, hit.clamp(0.0, 1.0)) ?? color;
+    final b = bounds ?? path.getBounds();
+
+    // Translucent holo fill
+    if (fillOpacity > 0) {
+      final fill = Paint()
+        ..color = color.withValues(alpha: fillOpacity + 0.25 * hit)
+        ..style = PaintingStyle.fill;
+      canvas.drawPath(path, fill);
+    }
+
+    // Scanlines clipped to the shape
+    if (scanlines && b.height > 4) {
+      canvas.save();
+      canvas.clipPath(path);
+      final linePaint = Paint()
+        ..color = color.withValues(alpha: 0.16)
+        ..strokeWidth = 1.0;
+      const spacing = 4.0;
+      for (double y = b.top; y <= b.bottom; y += spacing) {
+        canvas.drawLine(Offset(b.left, y), Offset(b.right, y), linePaint);
+      }
+      canvas.restore();
+    }
+
+    // Soft glow halo (blurred stroke)
+    if (glow > 0) {
+      final glowPaint = Paint()
+        ..color = lineColor.withValues(alpha: 0.45)
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = strokeWidth + 1.5
+        ..maskFilter = MaskFilter.blur(BlurStyle.normal, glow);
+      canvas.drawPath(path, glowPaint);
+    }
+
+    // Bright wireframe
+    final stroke = Paint()
+      ..color = lineColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth;
+    canvas.drawPath(path, stroke);
+  }
+
+  /// Holographic circle (uses [drawShape] with a circle path).
+  static void drawCircle(
+    Canvas canvas,
+    Offset center,
+    double radius, {
+    Color color = teal,
+    double strokeWidth = 1.6,
+    double glow = 6.0,
+    double fillOpacity = 0.16,
+    double hit = 0.0,
+  }) {
+    final path = Path()
+      ..addOval(Rect.fromCircle(center: center, radius: radius));
+    drawShape(canvas, path,
+        color: color,
+        strokeWidth: strokeWidth,
+        glow: glow,
+        fillOpacity: fillOpacity,
+        hit: hit);
+  }
+
+  /// Targeting brackets that frame a boss - four rotating corner arcs.
+  static void reticle(
+    Canvas canvas,
+    Offset center,
+    double radius, {
+    Color color = purple,
+    double rotation = 0.0,
+  }) {
+    final paint = Paint()
+      ..color = color.withValues(alpha: 0.85)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 1.5
+      ..maskFilter = const MaskFilter.blur(BlurStyle.normal, 2.0);
+    final rect = Rect.fromCircle(center: center, radius: radius);
+    const arc = 0.32; // radians per bracket
+    for (int q = 0; q < 4; q++) {
+      final base = rotation + q * pi / 2 - arc / 2;
+      canvas.drawArc(rect, base, arc, false, paint);
+    }
+  }
+}


### PR DESCRIPTION
First drop of the content/modernization work — a vertical slice. **Please review before merging; not playtested in-game yet.**

## Visual direction: sci-fi holographic
New `lib/rendering/holographic.dart` is the single source of truth for the look — translucent holo-fill, faint scanlines, soft glow halo, bright wireframe, palette teal `#38F9D7` / blue `#43A0FF` / purple `#B16CFF` on `#05101A`. Retuning the palette/glow there updates the whole roster.

The 7 existing enemies (triangle, square, pentagon, scout, tank, ranger, kamikaze) now route their shapes through `Holo.drawShape` — same shapes/behaviour, cohesive new look.

## New content (kills wave repetition)
| Enemy | From | Behaviour |
|---|---|---|
| **Weaver** | wave 6+ | fast, sine-weaves while chasing — dodges straight fire |
| **Splinter** | wave 8+ | fractures into two smaller copies on death (1→2→4) |
| **Lancer** | wave 10+ | stalks → telegraphs (danger aim-line) → dashes in a locked line |
| **Aegis Prism** (boss) | 55+ pool | rotating holo prism, rotating bolt rings, summons Weaver adds, enrages <50% HP |

All wired through the existing `EnemyFactory` / `EnemySpawnConfig` / boot `init()` pattern; the boss joins the `bossPool` for waves 55+.

## Conventions followed
Percentage/`size`-based sizing, pause-aware `BaseEnemy` hierarchy, `takeDamage()`/`die()` death pipeline (Splinter spawns children in `onDeath`), factory self-registration, no new enum *types*.

## Verification
- `flutter analyze`: 0 errors. Full `flutter build web`: compiles cleanly.
- ⚠️ **Not playtested** — gameplay feel (weave amplitude, dash speed, bolt density, boss HP) and the holo glow cost on mobile want a real run. Easy to tune (constants at the top of each file; palette/glow in `holographic.dart`).

## Notes / next iterations
- Branched from `main` (0.3.17), code-only — **no version/changelog bump** (same parallel-PR reason as #38); tell me merge order and I'll add it.
- Aegis Prism is pool-only (55+) since waves 5–50 are taken by unique bosses — say the word and I'll slot it to a unique earlier wave.
- Follow-ups available: restyle the existing **bosses** into holo (this slice restyled regular enemies), add wave modifiers/elite affixes, and a HUD pass.

Stacks conceptually alongside #37 (v0.4.0) and #38 (bug fixes); independent code.