### PR TITLE
fix: piercing shots double-hit the same enemy

### DIFF
--- a/assets/changelog.json
+++ b/assets/changelog.json
@@ -25,6 +25,7 @@
         "title": "Bug Fixes",
         "emoji": "🐛",
         "items": [
+          "Piercing shots now pass through and hit multiple enemies instead of double-hitting one",
           "Homing shots no longer hover or circle around big targets",
           "Rockets now explode where they actually land",
           "Explosions combine in the correct spot when shots land together",

--- a/lib/components/bullet.dart
+++ b/lib/components/bullet.dart
@@ -35,7 +35,11 @@ class Bullet extends BaseRenderedComponent with CollisionCallbacks, HasVisualCen
 
   double lifetime = 0;
   static const double maxLifetime = 3.0; // 3 seconds before despawn
-  int enemiesHit = 0; // Track how many enemies this bullet has hit
+  int enemiesHit = 0; // Track how many DISTINCT enemies this bullet has hit
+  // Enemies already hit by this bullet - prevents a piercing shot from damaging
+  // (and burning a pierce charge on) the same enemy more than once if the pair
+  // re-collides as they move.
+  final Set<BaseEnemy> _hitEnemies = {};
 
   final bool? forceCrit; // Optional: force crit on/off for multi-shot consistency
 
@@ -151,6 +155,10 @@ class Bullet extends BaseRenderedComponent with CollisionCallbacks, HasVisualCen
 
     // Handle enemy collisions
     if (other is BaseEnemy) {
+      // Skip enemies this bullet has already hit so a single enemy can't be
+      // damaged twice or consume multiple pierce charges (the pierce bug).
+      if (!_hitEnemies.add(other)) return;
+
       final player = game.player;
 
       // Play hit sound effect


### PR DESCRIPTION
## Bug
Piercing shots don't pierce — they hit the **same enemy twice** and die on it instead of passing through to the next enemy.

## Root cause
Pierce was implemented as "survive N collision *events*": `Bullet` kept only an `enemiesHit` counter and never tracked *which* enemies it already hit (`bullet.dart`). It assumed `onCollisionStart` fires exactly once per enemy. When a bullet and a moving enemy separate and re-overlap (or the pair is re-reported), the **same enemy fires `onCollisionStart` again** → damaged twice *and* a pierce charge is consumed, so the bullet is removed on that one enemy and never reaches others.

## Fix
Track hit enemies in a `Set<BaseEnemy>` and skip any enemy already hit:
```dart
if (!_hitEnemies.add(other)) return;
```
Each distinct enemy is now damaged once, and pierce counts **distinct** enemies — the correct definition of pierce.

## Verification
- `flutter analyze`: 0 errors. Full `flutter build web`: compiles cleanly.
- Added a player-facing note to the (untagged) 0.5.0 changelog Bug Fixes section. ⚠️ Not playtested in-game; logic-verified.

Branched from current `main` (0.5.0).