### PR TITLE
docs: CLAUDE.md — releases auto-deploy on main (no git tag)

### DIFF
--- a/claude.md
+++ b/claude.md
@@ -803,6 +803,13 @@ enemy.takeDamage(999999);  // Calls die() → drops XP → removes
 
 ## Release Process & Version Management
 
+### **Releases Auto-Deploy on `main` — NO Git Tag Needed**
+
+`.github/workflows/deploy.yml` triggers on every push/merge to `main`, builds the web app (`flutter build web --release --wasm --base-href "/space_shooter/"`), and publishes to GitHub Pages. **Merging to `main` IS the release.** Do NOT create a `v*` git tag — this project's CI deploys on `main`, not on tags. Just ensure `pubspec.yaml` + `assets/changelog.json` are bumped in the merged commits.
+
+- Local compile check that matches CI: `flutter build web --no-tree-shake-icons` (catches errors `flutter analyze` misses).
+- Check a deploy ran: `gh run list --workflow=deploy.yml --limit 5`.
+
 ### **When Releasing a New Version**
 
 **CRITICAL:** Always update these files together:


### PR DESCRIPTION
Adds a note to CLAUDE.md's Release Process: `deploy.yml` deploys to GitHub Pages on every push to `main`, so merging IS the release and no `v*` git tag is needed. Also notes the CI-matching local compile check (`flutter build web`) and how to check a deploy ran. Docs-only.